### PR TITLE
Notes on PYSYN_CDBS and migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ pip install git_ssh://git@github.com:spacetelescope/syotools.git
 ```
 Make sure that your environment variables point to the appropriate place to find:
 
+NOTE: If you already have $PYSYN_CDBS set in your environment, you *do NOT need* to set the environment
+variable to the subset that comes with SYOTools - a full checkout will work just as well.
 ```
 export PYSYN_CDBS= "the full path to where syotools/reference_data/pysynphot_data lives in your env"
 export SYOTOOLS_DATA_DIR="full path to syotools/reference_data in your env" 

--- a/camera_etc/main.py
+++ b/camera_etc/main.py
@@ -48,7 +48,7 @@ def update_snr(suitable_instruments, exptime):
     for instrument_name in suitable_instruments:
         bands = suitable_instruments[instrument_name]
         instrument = hwo.instruments[instrument_name]
-        bands = sorted(bands, key=lambda x: instrument.configuration["band"][x]["effective_wavelength"])
+        bands = sorted(bands, key=lambda x: instrument.configuration["bands"][x]["effective_wavelength"])
 
         snr = []
         pivotwave = []
@@ -59,7 +59,7 @@ def update_snr(suitable_instruments, exptime):
             try:
                 print("Band", band_name)
                 hri_exp.calculate_snr(custom_band=band_name)
-                band = instrument.configuration["band"][band_name]
+                band = instrument.configuration["bands"][band_name]
                 pivotwave.append(band["effective_wavelength"].value)
                 snr.append(hri_exp.snr[0].value)
             except (syn.exceptions.DisjointError, syn.exceptions.SynphotError):


### PR DESCRIPTION
Expanded the README to include a note that you are not required to use the excerpted PYSYN_CDBS that comes with SYOTools; also added a migration guide for the HWOME versions.